### PR TITLE
add links related to simple design

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,6 @@ You are free to replace Erlang with whatever programming language you want to di
   - [The Four Elements of Simple Design](http://blog.jbrains.ca/permalink/the-four-elements-of-simple-design)
   - [Putting An Age-Old Battle To Rest](http://blog.thecodewhisperer.com/permalink/putting-an-age-old-battle-to-rest)
   - Chapter 12 of [Clean Code](http://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882): Emergence
-    - Chapter 12: Emergence
 - Outside-in TDD [[part I](https://www.youtube.com/watch?v=XHnuMjah6ps) - [part II](https://www.youtube.com/watch?v=gs0rqDdz3ko) - [part III](https://www.youtube.com/watch?v=R9OAt9AOrzI)]
 - Interaction Driven Design:
   - [Sandro Mancuso @ Lean Agile Scotland "Crafted Design"](https://vimeo.com/107963074)

--- a/readme.md
+++ b/readme.md
@@ -47,10 +47,6 @@
 - [Effective Unit Testing](https://www.amazon.com/Effective-Unit-Testing-guide-developers/dp/1935182579)
   - Part 1: Foundations
   - Part 2: Catalog
-- [Beck Design Rules](https://martinfowler.com/bliki/BeckDesignRules.html)
-- [Emergent Design](http://ronjeffries.com/xprog/classics/expemergentdesign/)
-- [The Four Elements of Simple Design](http://blog.jbrains.ca/permalink/the-four-elements-of-simple-design)
-- [Putting An Age-Old Battle To Rest](http://blog.thecodewhisperer.com/permalink/putting-an-age-old-battle-to-rest)
 
 ## Session 3: Working with Legacy Code
 
@@ -186,8 +182,13 @@ You are free to replace Erlang with whatever programming language you want to di
 
 - [TDD by example](http://www.amazon.com/Test-Driven-Development-By-Example/dp/0321146530)
   - Patterns for Test-Driven Development
-- [Clean Code](http://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882)
-  - Chapter 12: Emergence
+- Simple Design
+  - [Beck Design Rules](https://martinfowler.com/bliki/BeckDesignRules.html)
+  - [Emergent Design](http://ronjeffries.com/xprog/classics/expemergentdesign/)
+  - [The Four Elements of Simple Design](http://blog.jbrains.ca/permalink/the-four-elements-of-simple-design)
+  - [Putting An Age-Old Battle To Rest](http://blog.thecodewhisperer.com/permalink/putting-an-age-old-battle-to-rest)
+  - Chapter 12 of [Clean Code](http://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882): Emergence
+    - Chapter 12: Emergence
 - Outside-in TDD [[part I](https://www.youtube.com/watch?v=XHnuMjah6ps) - [part II](https://www.youtube.com/watch?v=gs0rqDdz3ko) - [part III](https://www.youtube.com/watch?v=R9OAt9AOrzI)]
 - Interaction Driven Design:
   - [Sandro Mancuso @ Lean Agile Scotland "Crafted Design"](https://vimeo.com/107963074)

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,10 @@
 - [Effective Unit Testing](https://www.amazon.com/Effective-Unit-Testing-guide-developers/dp/1935182579)
   - Part 1: Foundations
   - Part 2: Catalog
+- [Beck Design Rules](https://martinfowler.com/bliki/BeckDesignRules.html)
+- [Emergent Design](http://ronjeffries.com/xprog/classics/expemergentdesign/)
+- [The Four Elements of Simple Design](http://blog.jbrains.ca/permalink/the-four-elements-of-simple-design)
+- [Putting An Age-Old Battle To Rest](http://blog.thecodewhisperer.com/permalink/putting-an-age-old-battle-to-rest)
 
 ## Session 3: Working with Legacy Code
 


### PR DESCRIPTION
I added to Session 2: Test-Driven Development a couple of links related to "simple design". If you don't think these links fit in the section I can try to open a new session, or you can suggest a different section as well.