### PR TITLE
#48 - Fixed url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ Enjoy!
   - Chapter 6: Objects and Data Structures
   - Chapter 7: Error Handling
   - Chapter 10: Classes
-- Read [The Pragmatic Programmer](https://pragprog.com/book/tpp/the-pragmatic-programmer)
+- Read [The Pragmatic Programmer](https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/)
   - Chapter 2: A Pragmatic Approach
   - Chapter 5: Bend or Break
   - Chapter 6: While You Are Coding


### PR DESCRIPTION
The previous url https://pragprog.com/titles/tpp20/the-pragmatic-programmer this exist anymore the new one is https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/